### PR TITLE
fix for FireFox 'SpeechRecognition is not a constructor'

### DIFF
--- a/src/withSpeech.js
+++ b/src/withSpeech.js
@@ -6,8 +6,14 @@ const head = arr => arr[0]
 const withSpeech = Comp => {
   class WithSpeech extends Component {
     componentDidMount = () => {
-      // Standardize DOM across Chrome, Safari & Firefox:
-      window.SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition
+      if (!window.SpeechRecognition) {
+        if (!window.webkitSpeechRecognition) {
+          // Implement graceful fail if browser doesn't support SpeechRecognition API
+          return
+        }
+
+        window.SpeechRecognition = window.webkitSpeechRecognition
+      }
 
       this.recognition = new window.SpeechRecognition()
       this.recognition.interimResults = true
@@ -40,11 +46,11 @@ const withSpeech = Comp => {
 
     render() {
       return (
-	<Comp
+        <Comp
           {...this.props}
           startListening={this.start}
           stopListening={this.stop}
-	/>
+        />
       )
     }
   }


### PR DESCRIPTION
#3 — Doesn’t work in Firefox?

There's currently no support for SpeechRecognition in FireFox:

<img width="1046" alt="screenshot 2018-06-16 14 23 01" src="https://user-images.githubusercontent.com/2607929/41502552-66143506-7171-11e8-997d-8dc22cc72891.png">

This checks if `window.SpeechRecognition` or `window.webkitSpeechRecognition` exists, if not it ends function execution. I'll leave it up to you how you want to handle browser incompatibility.